### PR TITLE
Create topic explicitly

### DIFF
--- a/consumer_integration_test.go
+++ b/consumer_integration_test.go
@@ -175,13 +175,16 @@ func TestGet_KafkaDown(t *testing.T) {
 	is.Equal("tcp", cause.Net)
 }
 
+// createTopic creates a topic and waits until its actually created.
+// Having topics auto-created is not an option since the writer
+// again doesn't wait for the topic to be actually created.
 func createTopic(t *testing.T, topic string) {
 	is := is.New(t)
 	c, err := skafka.Dial("tcp", "localhost:9092")
 	is.NoErr(err)
 	defer c.Close()
 
-	kt := skafka.TopicConfig{Topic: topic, NumPartitions: 3, ReplicationFactor: 1}
+	kt := skafka.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1}
 	err = c.CreateTopics(kt)
 	is.NoErr(err)
 	time.Sleep(2500 * time.Millisecond)

--- a/consumer_integration_test.go
+++ b/consumer_integration_test.go
@@ -178,14 +178,16 @@ func TestGet_KafkaDown(t *testing.T) {
 // createTopic creates a topic and waits until its actually created.
 // Having topics auto-created is not an option since the writer
 // again doesn't wait for the topic to be actually created.
+// Also see: https://github.com/segmentio/kafka-go/issues/219
 func createTopic(t *testing.T, topic string) {
 	is := is.New(t)
-	c, err := skafka.Dial("tcp", "localhost:9092")
-	is.NoErr(err)
-	defer c.Close()
 
-	kt := skafka.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1}
-	err = c.CreateTopics(kt)
+	client := skafka.Client{Addr: skafka.TCP("localhost")}
+	_, err := client.CreateTopics(
+		context.Background(),
+		&skafka.CreateTopicsRequest{Topics: []skafka.TopicConfig{
+			{Topic: topic, NumPartitions: 1, ReplicationFactor: 1},
+		}},
+	)
 	is.NoErr(err)
-	time.Sleep(2500 * time.Millisecond)
 }

--- a/consumer_integration_test.go
+++ b/consumer_integration_test.go
@@ -128,14 +128,11 @@ func waitForMessage(consumer kafka.Consumer, timeout time.Duration) (*skafka.Mes
 func sendTestMessages(t *testing.T, cfg kafka.Config, from int, to int) {
 	is := is.New(t)
 	writer := skafka.Writer{
-		Addr:                   skafka.TCP(cfg.Servers...),
-		Topic:                  cfg.Topic,
-		BatchSize:              1,
-		BatchTimeout:           10 * time.Millisecond,
-		WriteTimeout:           cfg.DeliveryTimeout,
-		RequiredAcks:           cfg.Acks,
-		MaxAttempts:            2,
-		AllowAutoTopicCreation: true,
+		Addr:         skafka.TCP(cfg.Servers...),
+		Topic:        cfg.Topic,
+		BatchSize:    1,
+		BatchTimeout: 10 * time.Millisecond,
+		MaxAttempts:  2,
 	}
 	defer writer.Close()
 
@@ -187,4 +184,5 @@ func createTopic(t *testing.T, topic string) {
 	kt := skafka.TopicConfig{Topic: topic, NumPartitions: 3, ReplicationFactor: 1}
 	err = c.CreateTopics(kt)
 	is.NoErr(err)
+	time.Sleep(2500 * time.Millisecond)
 }

--- a/consumer_integration_test.go
+++ b/consumer_integration_test.go
@@ -182,7 +182,7 @@ func TestGet_KafkaDown(t *testing.T) {
 func createTopic(t *testing.T, topic string) {
 	is := is.New(t)
 
-	client := skafka.Client{Addr: skafka.TCP("localhost")}
+	client := skafka.Client{Addr: skafka.TCP("localhost:9092")}
 	_, err := client.CreateTopics(
 		context.Background(),
 		&skafka.CreateTopicsRequest{Topics: []skafka.TopicConfig{


### PR DESCRIPTION
### Description

AllowAutoTopicCreation was initially added to writers in consumer_integration_test.go, since it helped fix an error with leaders not available. However, topics are already manually created, so that was more of a workaround.

On the other hand, waiting for a topic to become balanced increases test execution. Using kafka-go's Client and not Conn reduces the test execution time consistenly by around 5s.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
