### PR TITLE
Update version string

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -21,7 +21,7 @@ import (
 // version is set during the build process (i.e. the Makefile).
 // It follows Go's convention for module version, where the version
 // starts with the letter v, followed by a semantic version.
-var version = "v0.0.0-dev"
+var version = "v0.3.0"
 
 // Specification returns the Kafka plugin's specification.
 // Any changes here must also be reflected in the ReadMe.


### PR DESCRIPTION
This is used as a built-in plugin so the constant needs to contain the proper version, otherwise it will show up in Conduit as `builtin:kafka@v0.0.0-dev`.