### PR TITLE
Produce debezium key

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,9 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/segmentio/kafka-go"
-
 	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/segmentio/kafka-go"
 )
 
 const (
@@ -81,6 +80,10 @@ type Config struct {
 	SASLMechanism string
 	SASLUsername  string
 	SASLPassword  string
+
+	// IsRecordFormatDebezium detects if the connector middleware is configured
+	// to produce debezium records.
+	IsRecordFormatDebezium bool
 }
 
 func (c *Config) Test(ctx context.Context) error {
@@ -184,6 +187,16 @@ func Parse(cfg map[string]string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("invalid SASL config: %w", err)
 	}
+
+	// record format
+	recordFormat := cfg[sdk.DestinationWithRecordFormat{}.RecordFormatParameterName()]
+	if recordFormat != "" {
+		recordFormatType, _, _ := strings.Cut(recordFormat, "/")
+		if recordFormatType == (sdk.DebeziumConverter{}.Name()) {
+			parsed.IsRecordFormatDebezium = true
+		}
+	}
+
 	return parsed, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -458,3 +458,25 @@ func TestParseSASL(t *testing.T) {
 		})
 	}
 }
+
+func TestParse_RecordFormat(t *testing.T) {
+	testCases := map[string]bool{
+		"":              false,
+		"opencdc/json":  false,
+		"debezium/json": true,
+		"debezium/foo":  true,
+		"debezium":      true,
+	}
+	for recordFormat, wantIsRecordFormatDebezium := range testCases {
+		t.Run(recordFormat, func(t *testing.T) {
+			is := is.New(t)
+			parsed, err := Parse(map[string]string{
+				Servers:             "localhost:9092",
+				Topic:               "hello-world-topic",
+				"sdk.record.format": recordFormat,
+			})
+			is.NoErr(err)
+			is.Equal(parsed.IsRecordFormatDebezium, wantIsRecordFormatDebezium)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/conduitio/conduit-connector-sdk v0.4.3
+	github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230113192541-6cd5101ba73f
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/matryer/is v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230113192541-6cd5101ba73f
+	github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230118130111-0ec719fc6e5e
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/matryer/is v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/conduitio/conduit-connector-protocol v0.4.0 h1:hO6mB4Ft34+PbF1G2pDGHzZmCA/y5jj5wsIrluw4qFY=
 github.com/conduitio/conduit-connector-protocol v0.4.0/go.mod h1:xU4dsoPPCiW+1rJFwxkMUjhYs+HMte+XB/aFL6x94iM=
-github.com/conduitio/conduit-connector-sdk v0.4.3 h1:1PRbPWn4yWT3qtcGjcVE7hHiVnID+rY20x3b+SbM55I=
-github.com/conduitio/conduit-connector-sdk v0.4.3/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
+github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230113192541-6cd5101ba73f h1:2UIwaRclDaC9GstB5c2lY7hxJ78WPRdyY+gl2iH/DcQ=
+github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230113192541-6cd5101ba73f/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/conduitio/conduit-connector-protocol v0.4.0 h1:hO6mB4Ft34+PbF1G2pDGHzZmCA/y5jj5wsIrluw4qFY=
 github.com/conduitio/conduit-connector-protocol v0.4.0/go.mod h1:xU4dsoPPCiW+1rJFwxkMUjhYs+HMte+XB/aFL6x94iM=
-github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230113192541-6cd5101ba73f h1:2UIwaRclDaC9GstB5c2lY7hxJ78WPRdyY+gl2iH/DcQ=
-github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230113192541-6cd5101ba73f/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
+github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230118130111-0ec719fc6e5e h1:O8S+K/oNxW11puMCMsQ7/rYM6oBhb9XTaPSUYBdWrGk=
+github.com/conduitio/conduit-connector-sdk v0.4.4-0.20230118130111-0ec719fc6e5e/go.mod h1:SNz/Sn4zNuJNMELlr+HVe8Br8SpDea0EB4Gmh+Ha0+k=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
### Description

This change depends on changes in https://github.com/ConduitIO/conduit-connector-sdk/pull/48, once that's merged we should update the dependency to point to the latest commit in `main`.

This PR introduces the option of producing the key in a Kafka Connect compatible format (`{"schema":{...},"payload":{...}}`). This gets enabled if `sdk.record.format` is set to `debezium/*`.

NOT TESTED - we need to confirm this works first.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
