### PR TITLE
default to empty saslMechanism

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,7 +127,7 @@ func (c *Config) brokerHasCACert() bool {
 }
 
 func (c *Config) saslEnabled() bool {
-	return c.SASLUsername != "" && c.SASLPassword != ""
+	return c.SASLMechanism != ""
 }
 
 func Parse(cfg map[string]string) (Config, error) {
@@ -188,6 +188,16 @@ func Parse(cfg map[string]string) (Config, error) {
 }
 
 func setSASLConfigs(parsed *Config, cfg map[string]string) error {
+	mechanism, mechanismPresent := cfg[SASLMechanism]
+	// Check if SASL mechanism is empty
+	if mechanism == "" {
+		return nil
+	}
+	// check if the mechanism is valid
+	if !validSASLMechanism(mechanism) {
+		return fmt.Errorf("invalid SASL mechanism %q, expected one of: %v", mechanism, SASLMechanismValues)
+	}
+
 	var missingCreds []string
 	if cfg[SASLUsername] == "" {
 		missingCreds = append(missingCreds, SASLUsername)
@@ -198,20 +208,14 @@ func setSASLConfigs(parsed *Config, cfg map[string]string) error {
 	if len(missingCreds) == 1 {
 		return fmt.Errorf("SASL configuration incomplete, %v is missing", missingCreds[0])
 	}
-	mechanism, mechanismPresent := cfg[SASLMechanism]
+
 	// Mechanism specified, but credentials haven't been provided.
 	// Handles specifically the case where neither a username nor a password
 	// have been provided.
-	if mechanismPresent && len(missingCreds) != 0 {
+	if mechanismPresent && mechanism != "" && len(missingCreds) != 0 {
 		return errors.New("SASL mechanism provided, but username and password are missing")
 	}
 
-	if mechanism == "" {
-		mechanism = "PLAIN"
-	}
-	if !validSASLMechanism(mechanism) {
-		return fmt.Errorf("invalid SASL mechanism %q, expected one of: %v", mechanism, SASLMechanismValues)
-	}
 	parsed.SASLMechanism = mechanism
 	parsed.SASLUsername = cfg[SASLUsername]
 	parsed.SASLPassword = cfg[SASLPassword]

--- a/config_test.go
+++ b/config_test.go
@@ -265,8 +265,8 @@ func TestParse_Full(t *testing.T) {
 	is.Equal("ClientCert", parsed.ClientCert)
 	is.Equal("ClientKey", parsed.ClientKey)
 	is.Equal("CACert", parsed.CACert)
-	is.Equal("test-username", parsed.SASLUsername)
-	is.Equal("test-password", parsed.SASLPassword)
+	is.Equal("", parsed.SASLUsername) // empty because SASL mechanism is not provided
+	is.Equal("", parsed.SASLPassword)
 }
 
 func TestParse_Ack(t *testing.T) {
@@ -356,7 +356,7 @@ func TestParseSASL(t *testing.T) {
 		},
 		{
 			name:      "password missing",
-			mechanism: "",
+			mechanism: "PLAIN",
 			username:  "test-user",
 			password:  "",
 			expectation: func(cfg Config, err error, is *is.I) {
@@ -369,7 +369,7 @@ func TestParseSASL(t *testing.T) {
 		},
 		{
 			name:      "username missing",
-			mechanism: "",
+			mechanism: "PLAIN",
 			username:  "",
 			password:  "test-password",
 			expectation: func(cfg Config, err error, is *is.I) {
@@ -383,8 +383,6 @@ func TestParseSASL(t *testing.T) {
 		{
 			name:      "invalid mechanism",
 			mechanism: "SCRAM-SHA-1024",
-			username:  "test-username",
-			password:  "test-password",
 			expectation: func(cfg Config, err error, is *is.I) {
 				is.True(err != nil)
 				is.Equal(
@@ -394,15 +392,13 @@ func TestParseSASL(t *testing.T) {
 			},
 		},
 		{
-			name:      "default mechanism is PLAIN",
-			mechanism: "",
-			username:  "test-username",
-			password:  "test-password",
+			name:     "default mechanism is empty",
+			username: "",
 			expectation: func(cfg Config, err error, is *is.I) {
 				is.True(err == nil)
-				is.Equal(cfg.SASLMechanism, "PLAIN")
-				is.Equal(cfg.SASLUsername, "test-username")
-				is.Equal(cfg.SASLPassword, "test-password")
+				is.Equal(cfg.SASLMechanism, "")
+				is.Equal(cfg.SASLUsername, "")
+				is.Equal(cfg.SASLPassword, "")
 			},
 		},
 		{

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -183,10 +183,11 @@ func TestReaderConfig_ServerTLS(t *testing.T) {
 func TestReaderConfig_SASL_Plain(t *testing.T) {
 	is := is.New(t)
 	config := Config{
-		Servers:      []string{"test-host:9092"},
-		Topic:        "test-topic",
-		SASLUsername: "sasl-username",
-		SASLPassword: "sasl-password",
+		Servers:       []string{"test-host:9092"},
+		Topic:         "test-topic",
+		SASLMechanism: "PLAIN",
+		SASLUsername:  "sasl-username",
+		SASLPassword:  "sasl-password",
 	}
 	c := &segmentConsumer{}
 	err := c.newReader(config, "group-id")

--- a/destination.go
+++ b/destination.go
@@ -76,19 +76,19 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 				"If `true`, accepts any certificate presented by the server and any host name in that certificate.",
 		},
 		SASLMechanism: {
-			Default:     "PLAIN",
+			Default:     "",
 			Required:    false,
 			Description: "SASL mechanism to be used. Possible values: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512.",
 		},
 		SASLUsername: {
 			Default:     "",
 			Required:    false,
-			Description: "SASL username. If provided, a password needs to be provided too.",
+			Description: "SASL username. required if saslMechanism is provided.",
 		},
 		SASLPassword: {
 			Default:     "",
 			Required:    false,
-			Description: "SASL password. If provided, a username needs to be provided too.",
+			Description: "SASL password. required if saslMechanism is provided.",
 		},
 	}
 }

--- a/segment_writer_test.go
+++ b/segment_writer_test.go
@@ -97,10 +97,11 @@ func TestSegmentWriter_ServerTLS(t *testing.T) {
 func TestSegmentWriter_SASL_Plain(t *testing.T) {
 	is := is.New(t)
 	config := Config{
-		Servers:      []string{"test-host:9092"},
-		Topic:        "test-topic",
-		SASLUsername: "sasl-username",
-		SASLPassword: "sasl-password",
+		Servers:       []string{"test-host:9092"},
+		Topic:         "test-topic",
+		SASLMechanism: "PLAIN",
+		SASLUsername:  "sasl-username",
+		SASLPassword:  "sasl-password",
 	}
 	p := &segmentProducer{}
 	err := p.init(config)

--- a/source.go
+++ b/source.go
@@ -83,19 +83,19 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 				"If `true`, accepts any certificate presented by the server and any host name in that certificate.",
 		},
 		SASLMechanism: {
-			Default:     "PLAIN",
+			Default:     "",
 			Required:    false,
 			Description: "SASL mechanism to be used. Possible values: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512.",
 		},
 		SASLUsername: {
 			Default:     "",
 			Required:    false,
-			Description: "SASL username. If provided, a password needs to be provided too.",
+			Description: "SASL username. required if saslMechanism is provided.",
 		},
 		SASLPassword: {
 			Default:     "",
 			Required:    false,
-			Description: "SASL password. If provided, a username needs to be provided too.",
+			Description: "SASL password. required if saslMechanism is provided.",
 		},
 	}
 }


### PR DESCRIPTION
### Description

saslMechanism default is an empty value now.
username and password are only required if saslMechanism is not empty

Fixes # (issue)

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
