### PR TITLE
Producer: retry on any temp. error

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -19,7 +19,6 @@ package kafka
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -172,7 +171,8 @@ func (p *segmentProducer) sendRetryable(ctx context.Context, messages []kafka.Me
 		retry.RetryIf(func(err error) bool {
 			// this can happen when the topic doesn't exist and the broker has auto-create enabled
 			// we give it some time to process topic metadata and retry
-			return errors.Is(err, kafka.LeaderNotAvailable)
+			kErr, ok := err.(kafka.Error)
+			return ok && kErr.Temporary()
 		}),
 		retry.OnRetry(func(n uint, err error) {
 			sdk.Logger(ctx).

--- a/producer.go
+++ b/producer.go
@@ -171,8 +171,8 @@ func (p *segmentProducer) sendRetryable(ctx context.Context, messages []kafka.Me
 		retry.RetryIf(func(err error) bool {
 			// this can happen when the topic doesn't exist and the broker has auto-create enabled
 			// we give it some time to process topic metadata and retry
-			kErr, ok := err.(kafka.Error)
-			return ok && kErr.Temporary()
+			kafkaErr, ok := err.(kafka.Error)
+			return ok && kafkaErr.Temporary()
 		}),
 		retry.OnRetry(func(n uint, err error) {
 			sdk.Logger(ctx).


### PR DESCRIPTION
### Description

Make the producer retry on any error which the kafka-go client considers temporary.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
