### PR TITLE
Add message headers to produced record

### DIFF
--- a/source.go
+++ b/source.go
@@ -25,7 +25,8 @@ import (
 
 const (
 	// MetadataKafkaTopic is the metadata key for storing the kafka topic
-	MetadataKafkaTopic = "kafka.topic"
+	MetadataKafkaTopic        = "kafka.topic"
+	MetadataKafkaHeaderPrefix = "kafka.header."
 )
 
 type Source struct {
@@ -98,6 +99,9 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 
 	metadata := sdk.Metadata{MetadataKafkaTopic: rec.Topic}
 	metadata.SetCreatedAt(rec.Timestamp)
+	for _, h := range rec.Headers {
+		metadata[MetadataKafkaHeaderPrefix+h.Key] = string(h.Value)
+	}
 
 	return sdk.Util.Source.NewRecordCreate(
 		source.Position{

--- a/source_test.go
+++ b/source_test.go
@@ -16,16 +16,16 @@ package kafka
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/twmb/franz-go/pkg/kgo"
 	"strconv"
 	"testing"
 
 	"github.com/conduitio/conduit-connector-kafka/source"
 	"github.com/conduitio/conduit-connector-kafka/test"
 	sdk "github.com/conduitio/conduit-connector-sdk"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/matryer/is"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"go.uber.org/mock/gomock"
 )
 


### PR DESCRIPTION
### Description

Adds message headers the the produced record. The headers are prefixed with `kafka.header.`. Also, the values, which are originally `[]byte` are cast to strings.

Fixes #125.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
