### PR TITLE
handle empty parsed topic

### DIFF
--- a/destination/config.go
+++ b/destination/config.go
@@ -149,6 +149,11 @@ func (c Config) ParseTopic() (topic string, f TopicFn, err error) {
 		if err := t.Execute(&buf, r); err != nil {
 			return "", fmt.Errorf("failed to execute topic template: %w", err)
 		}
-		return buf.String(), nil
+		topic := buf.String()
+		if topic == "" {
+			return "", fmt.Errorf("topic not found on record %s", r.Key.Bytes())
+		}
+
+		return topic, nil
 	}, nil
 }

--- a/destination/config.go
+++ b/destination/config.go
@@ -151,7 +151,10 @@ func (c Config) ParseTopic() (topic string, f TopicFn, err error) {
 		}
 		topic := buf.String()
 		if topic == "" {
-			return "", fmt.Errorf("topic not found on record %s using template %s", r.Key.Bytes(), c.Topic)
+			return "", fmt.Errorf(
+				"topic not found on record %s using template %s",
+				string(r.Key.Bytes()), c.Topic,
+			)
 		}
 
 		return topic, nil

--- a/destination/config.go
+++ b/destination/config.go
@@ -151,7 +151,7 @@ func (c Config) ParseTopic() (topic string, f TopicFn, err error) {
 		}
 		topic := buf.String()
 		if topic == "" {
-			return "", fmt.Errorf("topic not found on record %s", r.Key.Bytes())
+			return "", fmt.Errorf("topic not found on record %s using template %s", r.Key.Bytes(), c.Topic)
 		}
 
 		return topic, nil

--- a/destination/config_test.go
+++ b/destination/config_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/matryer/is"
 )
 
@@ -84,4 +85,25 @@ func TestConfig_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfig_ParseTopic_ErrorOnIndexNotFound(t *testing.T) {
+	is := is.New(t)
+	template := `{{ index .Metadata "topiccc" }}`
+
+	cfg := Config{Topic: template}
+	topic, getTopic, err := cfg.ParseTopic()
+	is.NoErr(err)
+
+	is.Equal(topic, "")
+
+	rec := sdk.Record{
+		Metadata: map[string]string{
+			"topic": "testtopic",
+		},
+	}
+	topic, err = getTopic(rec)
+	is.True(err != nil) // expected error on topic not found
+
+	is.Equal(topic, "")
 }

--- a/destination/config_test.go
+++ b/destination/config_test.go
@@ -87,7 +87,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestConfig_ParseTopic_ErrorOnTopicNotFound(t *testing.T) {
+func TestConfig_ParseTopic_DoesErrorOnTopicNotFound(t *testing.T) {
 	is := is.New(t)
 	template := `{{ index .Metadata "topiccc" }}`
 

--- a/destination/config_test.go
+++ b/destination/config_test.go
@@ -98,11 +98,13 @@ func TestConfig_ParseTopic_DoesErrorOnTopicNotFound(t *testing.T) {
 	is.Equal(topic, "")
 
 	rec := sdk.Record{
+		Key: sdk.RawData("testkey"),
 		Metadata: map[string]string{
 			"topic": "testtopic",
 		},
 	}
 	topic, err = getTopic(rec)
+	is.True(err != nil)                                                 // expected error on topic not found
 	is.True(strings.Contains(err.Error(), "topic not found on record")) // expected topic not found error
 
 	is.Equal(topic, "")

--- a/destination/config_test.go
+++ b/destination/config_test.go
@@ -87,7 +87,7 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestConfig_ParseTopic_ErrorOnIndexNotFound(t *testing.T) {
+func TestConfig_ParseTopic_ErrorOnTopicNotFound(t *testing.T) {
 	is := is.New(t)
 	template := `{{ index .Metadata "topiccc" }}`
 
@@ -103,7 +103,7 @@ func TestConfig_ParseTopic_ErrorOnIndexNotFound(t *testing.T) {
 		},
 	}
 	topic, err = getTopic(rec)
-	is.True(err != nil) // expected error on topic not found
+	is.True(strings.Contains(err.Error(), "topic not found on record")) // expected topic not found error
 
 	is.Equal(topic, "")
 }


### PR DESCRIPTION
### Description

Adds error on topic not found (empty topic) when using multicollection mode. That can happen if the user makes makes a mistake mispelling the topic template, as shown in the unit test. This is a *refactoring* change.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
