### PR TITLE
change bytes.Buffer for strings.Builder

### DIFF
--- a/destination/config.go
+++ b/destination/config.go
@@ -17,7 +17,6 @@
 package destination
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
@@ -143,13 +142,13 @@ func (c Config) ParseTopic() (topic string, f TopicFn, err error) {
 	}
 
 	// The topic is a valid template, return TopicFn.
-	var buf bytes.Buffer
+	var sb strings.Builder
 	return "", func(r opencdc.Record) (string, error) {
-		buf.Reset()
-		if err := t.Execute(&buf, r); err != nil {
+		sb.Reset()
+		if err := t.Execute(&sb, r); err != nil {
 			return "", fmt.Errorf("failed to execute topic template: %w", err)
 		}
-		topic := buf.String()
+		topic := sb.String()
 		if topic == "" {
 			return "", fmt.Errorf(
 				"topic not found on record %s using template %s",


### PR DESCRIPTION
### Description

Replaces `bytes.Buffer` usage for `strings.Builder`. The later is more optimized to write strings, so this pr should result into a small performance improvement.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
