### PR TITLE
Flush consumer offsets block using delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ pipelines:
           # Type: string
           # Required: no
           clientKey: ""
+          # CommitOffsetsDelay defines on how often consumed offsets should be
+          # commited.
+          # Type: duration
+          # Required: no
+          commitOffsetsDelay: "5s"
+          # CommitOffsetsSize defines the number of consumed offsets to be
+          # committed at a time.
+          # Type: int
+          # Required: no
+          commitOffsetsSize: "1000"
           # GroupID defines the consumer group id.
           # Type: string
           # Required: no

--- a/connector.yaml
+++ b/connector.yaml
@@ -79,6 +79,18 @@ specification:
         type: string
         default: ""
         validations: []
+      - name: commitOffsetsDelay
+        description: CommitOffsetsDelay defines on how often consumed offsets should be commited.
+        type: duration
+        default: 5s
+        validations: []
+      - name: commitOffsetsSize
+        description: CommitOffsetsSize defines the number of consumed offsets to be committed at a time.
+        type: int
+        default: "1000"
+        validations:
+          - type: greater-than
+            value: "-1"
       - name: groupID
         description: GroupID defines the consumer group id.
         type: string

--- a/source/config.go
+++ b/source/config.go
@@ -17,6 +17,7 @@ package source
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/conduitio/conduit-connector-kafka/common"
 	sdk "github.com/conduitio/conduit-connector-sdk"
@@ -37,6 +38,10 @@ type Config struct {
 	GroupID string `json:"groupID"`
 	// RetryGroupJoinErrors determines whether the connector will continually retry on group join errors.
 	RetryGroupJoinErrors bool `json:"retryGroupJoinErrors" default:"true"`
+	// CommitOffsetsSize defines the number of consumed offsets to be committed at a time.
+	CommitOffsetsSize int `json:"commitOffsetsSize" default:"1000" validate:"gt=-1"`
+	// CommitOffsetsDelay defines on how often consumed offsets should be commited.
+	CommitOffsetsDelay time.Duration `json:"commitOffsetsDelay" default:"5s"`
 }
 
 func (c *Config) Validate(ctx context.Context) error {

--- a/source/franz.go
+++ b/source/franz.go
@@ -158,7 +158,10 @@ func (a *batchAcker) Ack(ctx context.Context) error {
 func (a *batchAcker) Flush(ctx context.Context) error {
 	a.m.Lock()
 	defer a.m.Unlock()
-	defer a.flushTimer.Reset(a.batchDelay)
+
+	if a.batchDelay > 0 {
+		defer a.flushTimer.Reset(a.batchDelay)
+	}
 
 	if a.curBatchIndex == 0 {
 		return nil // nothing to flush

--- a/source/franz_test.go
+++ b/source/franz_test.go
@@ -99,7 +99,7 @@ func Test_FranzConsumer_Consume_Success(t *testing.T) {
 
 	c := &FranzConsumer{
 		client:               cl,
-		acker:                newBatchAcker(cl, 1000),
+		acker:                newBatchAcker(cl, 1000, 2*time.Second),
 		iter:                 &kgo.FetchesRecordIter{},
 		retryGroupJoinErrors: true,
 	}
@@ -130,7 +130,7 @@ func Test_FranzConsumer_Consume_RetryGroupJoinError(t *testing.T) {
 
 	c := &FranzConsumer{
 		client:               cl,
-		acker:                newBatchAcker(cl, 1000),
+		acker:                newBatchAcker(cl, 1000, 2*time.Second),
 		iter:                 &kgo.FetchesRecordIter{},
 		retryGroupJoinErrors: true,
 	}


### PR DESCRIPTION
### Description

Consumer offsets are flushed in blocks for efficiency.
This change adds configuration params to allow the size of the block and delay between flushes to be configured.


### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-kafka/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
