### PR TITLE
chore: re-release v0.12.5 (signed-artifact fixes)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,5 +106,5 @@ jobs:
           # fragment. Omit on subsequent version bumps (routing.Decide ignores
           # it once the name exists).
           first-registration-identity-ref-pattern: 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+'
-          provenance-bundle-url: ${{ needs.provenance.outputs.provenance-bundle-url }}
+          provenance-bundle-url: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ needs.provenance.outputs.provenance-name }}
           index-repo-token: ${{ secrets.REGISTRY_INDEX_PR_TOKEN }}

--- a/connector.yaml
+++ b/connector.yaml
@@ -37,7 +37,7 @@ specification:
       the destination (defaults to 0, no batching)
     - `sdk.batch.delay`: maximum delay before an incomplete batch is written to the
       destination (defaults to 0, no limit)
-  version: v0.12.4
+  version: v0.12.5
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
Re-release with the full fix set (new bundle format, tar.gz packaging, provenance URL) validated end-to-end on conduit-connector-file. Tier-3.